### PR TITLE
Do not ship randomness field in json on v2 API at all

### DIFF
--- a/routes.go
+++ b/routes.go
@@ -23,13 +23,13 @@ func SetupRoutes(r *chi.Mux, client *grpc.Client) {
 			r.Get("/chains/{chainhash:[0-9A-Fa-f]{64}}/info", GetInfoV2(client))
 			r.Get("/chains/{chainhash:[0-9A-Fa-f]{64}}/health", GetHealth(client))
 			r.Get("/chains/{chainhash:[0-9A-Fa-f]{64}}/rounds/{round:\\d+}", GetBeacon(client, true))
-			r.Get("/chains/{chainhash:[0-9A-Fa-f]{64}}/rounds/latest", GetLatest(client))
+			r.Get("/chains/{chainhash:[0-9A-Fa-f]{64}}/rounds/latest", GetLatest(client, true))
 
 			r.Get("/beacons", GetBeaconIds(client))
 			r.Get("/beacons/{beaconID}/info", GetInfoV2(client))
 			r.Get("/beacons/{beaconID}/health", GetHealth(client))
 			r.Get("/beacons/{beaconID}/rounds/{round:\\d+}", GetBeacon(client, true))
-			r.Get("/beacons/{beaconID}/rounds/latest", GetLatest(client))
+			r.Get("/beacons/{beaconID}/rounds/latest", GetLatest(client, true))
 		})
 	})
 
@@ -39,17 +39,16 @@ func SetupRoutes(r *chi.Mux, client *grpc.Client) {
 		r.Use(addCommonHeaders)
 
 		r.Use(apiVersionCtx("v1"))
-
 		r.Get("/chains", GetChains(client))
+
 		r.Get("/info", GetInfoV1(client))
 		r.Get("/health", GetHealth(client))
-
-		r.Get("/public/latest", GetLatest(client))
 		r.Get("/public/{round:\\d+}", GetBeacon(client, false))
+		r.Get("/public/latest", GetLatest(client, false))
 
-		r.Get("/{chainhash:[0-9A-Fa-f]{64}}/public/latest", GetLatest(client))
-		r.Get("/{chainhash:[0-9A-Fa-f]{64}}/public/{round:\\d+}", GetBeacon(client, false))
 		r.Get("/{chainhash:[0-9A-Fa-f]{64}}/info", GetInfoV1(client))
 		r.Get("/{chainhash:[0-9A-Fa-f]{64}}/health", GetHealth(client))
+		r.Get("/{chainhash:[0-9A-Fa-f]{64}}/public/{round:\\d+}", GetBeacon(client, false))
+		r.Get("/{chainhash:[0-9A-Fa-f]{64}}/public/latest", GetLatest(client, false))
 	})
 }


### PR DESCRIPTION
The latest endpoint wasn't handling that properly yet. Now this should work alright.