### PR TITLE
Add input validation for HTTP round parameter

### DIFF
--- a/main.go
+++ b/main.go
@@ -31,6 +31,14 @@ var (
 )
 
 func init() {
+	// Skip flag parsing during tests
+	if len(os.Args) > 0 {
+		for _, arg := range os.Args {
+			if arg == "-test.v" || arg == "-test.run" || strings.HasPrefix(arg, "-test.") {
+				return
+			}
+		}
+	}
 	flag.Parse()
 	slog.SetLogLoggerLevel(getLogLevel())
 }

--- a/routes_handler_test.go
+++ b/routes_handler_test.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadRound(t *testing.T) {
+	testCases := []struct {
+		name        string
+		round       string
+		expectError bool
+		expectedMsg string
+		expectedVal uint64
+		description string
+	}{
+		{
+			name:        "empty round parameter",
+			round:       "",
+			expectError: true,
+			expectedMsg: "round parameter is required",
+			description: "empty round should return error",
+		},
+		{
+			name:        "invalid format - non-numeric",
+			round:       "abc",
+			expectError: true,
+			expectedMsg: "invalid round number",
+			description: "non-numeric round should return error",
+		},
+		{
+			name:        "invalid format - negative",
+			round:       "-1",
+			expectError: true,
+			expectedMsg: "invalid round number",
+			description: "negative round should return error",
+		},
+		{
+			name:        "invalid format - decimal",
+			round:       "1.5",
+			expectError: true,
+			expectedMsg: "invalid round number",
+			description: "decimal round should return error",
+		},
+		{
+			name:        "extremely large number - parse error",
+			round:       "999999999999999999999999999999999999999999999999999999999999999999999999",
+			expectError: true,
+			expectedMsg: "invalid round number",
+			description: "extremely large round (parse error) should return error",
+		},
+		{
+			name:        "large but parseable number exceeding reasonable max",
+			round:       "1152921504606846977", // 2^60 + 1
+			expectError: true,
+			expectedMsg: "exceeds maximum allowed value",
+			description: "round exceeding reasonable maximum should return error",
+		},
+		{
+			name:        "valid round number",
+			round:       "1",
+			expectError: false,
+			expectedVal: 1,
+			description: "valid round should parse successfully",
+		},
+		{
+			name:        "valid large round number",
+			round:       "1152921504606846976", // 2^60 (max allowed)
+			expectError: false,
+			expectedVal: 1152921504606846976,
+			description: "valid large round at maximum should parse successfully",
+		},
+		{
+			name:        "zero round",
+			round:       "0",
+			expectError: false,
+			expectedVal: 0,
+			description: "zero round should parse successfully",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create a chi router and request
+			r := chi.NewRouter()
+			r.Get("/test/{round}", func(w http.ResponseWriter, r *http.Request) {
+				round, err := readRound(r)
+				if tc.expectError {
+					require.Error(t, err, tc.description)
+					if tc.expectedMsg != "" {
+						require.Contains(t, err.Error(), tc.expectedMsg, tc.description)
+					}
+				} else {
+					require.NoError(t, err, tc.description)
+					require.Equal(t, tc.expectedVal, round, tc.description)
+				}
+			})
+
+			req := httptest.NewRequest("GET", "/test/"+tc.round, nil)
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, req)
+		})
+	}
+}
+
+func TestReadRoundDirect(t *testing.T) {
+	// Test empty round parameter
+	r := chi.NewRouter()
+	r.Get("/test/{round}", func(w http.ResponseWriter, r *http.Request) {
+		round, err := readRound(r)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "round parameter is required")
+		require.Equal(t, uint64(0), round)
+	})
+	req := httptest.NewRequest("GET", "/test/", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	// Test valid round
+	r = chi.NewRouter()
+	r.Get("/test/{round}", func(w http.ResponseWriter, r *http.Request) {
+		round, err := readRound(r)
+		require.NoError(t, err)
+		require.Equal(t, uint64(123), round)
+	})
+	req = httptest.NewRequest("GET", "/test/123", nil)
+	w = httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	// Test invalid round
+	r = chi.NewRouter()
+	r.Get("/test/{round}", func(w http.ResponseWriter, r *http.Request) {
+		round, err := readRound(r)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid round number")
+		require.Equal(t, uint64(0), round)
+	})
+	req = httptest.NewRequest("GET", "/test/abc", nil)
+	w = httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	
+	// Test round exceeding maximum
+	maxRound := strconv.FormatUint(uint64(1<<60)+1, 10)
+	r = chi.NewRouter()
+	r.Get("/test/{round}", func(w http.ResponseWriter, r *http.Request) {
+		round, err := readRound(r)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "exceeds maximum allowed value")
+		require.Equal(t, uint64(0), round)
+	})
+	req = httptest.NewRequest("GET", "/test/"+maxRound, nil)
+	w = httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+}


### PR DESCRIPTION


## Problem

The HTTP handlers for `/public/{round}`, `/{chainHash}/public/{round}`, and the V2 API routes (`/chains/{chainhash}/rounds/{round}`, `/beacons/{beaconID}/rounds/{round}`) parse the round number from the URL but don't perform comprehensive input validation. While `strconv.ParseUint` handles some validation (overflow, negative numbers), the API doesn't provide early validation feedback with clear error messages or reasonable maximum limit checks.

**Location:** `routes_handler.go:22-30`

**Previous Code:**
```go
roundStr := chi.URLParam(r, "round")
round, err := strconv.ParseUint(roundStr, 10, 64)
if err != nil {
    w.Header().Set("Cache-Control", "public, max-age=604800, immutable")
    slog.Error("unable to parse round", "error", err)
    http.Error(w, "Failed to parse round. Err: "+err.Error(), http.StatusBadRequest)
    return
}
```

## Solution

1. **Added input validation:** Created `readRound` helper function with:
   - Empty parameter check
   - Improved error messages with context using `fmt.Errorf` with error wrapping (`%w`)
   - Reasonable maximum validation (2^60 = 1,152,921,504,606,846,976) to prevent issues with time calculations

2. **Improved error handling:** Updated error logging to include client information and request path for better debugging

3. **Added comprehensive test coverage:** Added `TestReadRound` and `TestReadRoundDirect` test functions with 9 test cases covering:
   - Invalid format (non-numeric strings)
   - Negative numbers
   - Decimal numbers
   - Extremely large numbers (parse errors)
   - Large but parseable numbers exceeding reasonable maximum
   - Valid round numbers
   - Valid large round numbers at maximum
   - Zero round

4. **Fixed test infrastructure:** Updated `main.go` to skip flag parsing during tests to prevent test failures

## Changes

- **`routes_handler.go`**: 
  - Added `readRound` helper function with validation and better error messages
  - Updated `GetBeacon` to use `readRound` and include client/path in error logs
  
- **`routes_handler_test.go`** (new file): 
  - Added `TestReadRound` test function with comprehensive test cases
  - Added `TestReadRoundDirect` for direct function testing

- **`main.go`**: 
  - Updated `init()` to skip flag parsing during tests (prevents test binary flag conflicts)

## Testing

- [X] All new tests pass: `go test -v -run TestReadRound`
- [X] Code compiles successfully: `go build ./...`
- [X] No linter errors
- [X] Existing functionality preserved

## Impact

This enhancement ensures that:

- Users receive clear, actionable error messages for invalid round parameters
- Extremely large round numbers are caught early with descriptive errors
- The API provides better input validation at the HTTP layer
- Security is improved by validating inputs before processing
- Error responses are properly formatted with meaningful messages
- Better debugging capabilities with enhanced error logging

## Related

This addresses the same concern raised in [drand/drand#1447](https://github.com/drand/drand/pull/1448), but implemented in the http-relay repository where HTTP handling is now maintained (as recommended by @AnomalRoil). The original PR in drand/drand has been closed in favor of this implementation.
