### PR TITLE
Fix JWT valid methods parsing in auth middleware

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -38,7 +38,7 @@ func AddAuth(next http.Handler) http.Handler {
 				return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
 			}
 			return jwtSecret, nil
-		}, jwt.WithValidMethods([]string{"HS256,HS384"}))
+		}, jwt.WithValidMethods([]string{"HS256", "HS384"}))
 		if err != nil {
 			slog.Error("Unable to parse JWT!", "err", err)
 			http.Error(w, "Invalid JWT", http.StatusUnauthorized)

--- a/auth_test.go
+++ b/auth_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAddAuth_AllowsHS256AndHS384(t *testing.T) {
+	// 128-byte key hex encoded (256 chars)
+	secretHex := strings.Repeat("a", 256)
+	t.Setenv("DRAND_AUTH_KEY", secretHex)
+
+	secret, err := hex.DecodeString(secretHex)
+	require.NoError(t, err)
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	protected := AddAuth(next)
+
+	for _, tc := range []struct {
+		name   string
+		method jwt.SigningMethod
+	}{
+		{name: "hs256", method: jwt.SigningMethodHS256},
+		{name: "hs384", method: jwt.SigningMethodHS384},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			token := jwt.New(tc.method)
+			signed, err := token.SignedString(secret)
+			require.NoError(t, err)
+
+			r := httptest.NewRequest(http.MethodGet, "/v2/chains", nil)
+			r.Header.Set("Authorization", "Bearer "+signed)
+			w := httptest.NewRecorder()
+
+			protected.ServeHTTP(w, r)
+			require.Equal(t, http.StatusOK, w.Code)
+		})
+	}
+}
+
+func TestAddAuth_RejectsHS512(t *testing.T) {
+	// Ensure the env var is present to avoid log.Fatal in AddAuth initialization.
+	secretHex := strings.Repeat("b", 256)
+	t.Setenv("DRAND_AUTH_KEY", secretHex)
+
+	secret, err := hex.DecodeString(secretHex)
+	require.NoError(t, err)
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	protected := AddAuth(next)
+
+	token := jwt.New(jwt.SigningMethodHS512)
+	signed, err := token.SignedString(secret)
+	require.NoError(t, err)
+
+	r := httptest.NewRequest(http.MethodGet, "/v2/chains", nil)
+	r.Header.Set("Authorization", "Bearer "+signed)
+	w := httptest.NewRecorder()
+
+	protected.ServeHTTP(w, r)
+	require.Equal(t, http.StatusUnauthorized, w.Code)
+}
+

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 	"os/signal"
 	"strings"
 	"syscall"
+	"testing"
 	"time"
 
 	"github.com/drand/http-relay/grpc"
@@ -32,10 +33,8 @@ var (
 
 func init() {
 	// Skip flag parsing during tests (Go test injects -test.* flags which are unknown to our flagset).
-	for _, arg := range os.Args {
-		if arg == "-test.v" || arg == "-test.run" || strings.HasPrefix(arg, "-test.") {
-			return
-		}
+	if testing.Testing() {
+		return
 	}
 	flag.Parse()
 	slog.SetLogLoggerLevel(getLogLevel())

--- a/main.go
+++ b/main.go
@@ -31,6 +31,12 @@ var (
 )
 
 func init() {
+	// Skip flag parsing during tests (Go test injects -test.* flags which are unknown to our flagset).
+	for _, arg := range os.Args {
+		if arg == "-test.v" || arg == "-test.run" || strings.HasPrefix(arg, "-test.") {
+			return
+		}
+	}
 	flag.Parse()
 	slog.SetLogLoggerLevel(getLogLevel())
 }


### PR DESCRIPTION


## Problem

When JWT auth is enabled, the middleware rejected valid tokens signed with HS256 or HS384.

This happened because `jwt.WithValidMethods` was configured with a single comma-separated string (`"HS256,HS384"`) instead of two entries (`"HS256"`, `"HS384"`), so the library never considered `"HS256"` / `"HS384"` as allowed.

Additionally, running tests for package `main` failed because `flag.Parse()` ran during `go test` and the binary received `-test.*` flags unknown to this project’s flagset.

## Solution

1. **Fix allowed algorithms list**: Pass `[]string{"HS256", "HS384"}` to `jwt.WithValidMethods`.
2. **Make tests runnable**: Skip `flag.Parse()` in `init()` when running under `go test`.
3. **Add coverage**: Add tests proving HS256/HS384 are accepted and HS512 is rejected.

## Changes

- **`http-relay/auth.go`**
  - Fix `jwt.WithValidMethods` configuration to correctly allow `HS256` and `HS384`.
- **`http-relay/main.go`**
  - Skip `flag.Parse()` during tests to avoid failing on `-test.*` flags.
- **`http-relay/auth_test.go`**
  - Add tests for the auth middleware:
    - HS256 and HS384 succeed (200).
    - HS512 is rejected (401).

## Testing

```bash
go test ./...
```

## Notes

- This is a behavior fix: when auth is enabled, valid HS256/HS384 tokens now authenticate correctly.

