### PR TITLE
Add error handling for HTTP response writes

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -60,7 +60,9 @@ func serveMetrics() {
 	}))
 	http.Handle("/chanz", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		slog.Debug("display channelz data on /chanz")
-		w.Write([]byte(grpc.UpdateMetrics(mClient)))
+		if _, err := w.Write([]byte(grpc.UpdateMetrics(mClient))); err != nil {
+			slog.Error("failed to write channelz response", "error", err)
+		}
 	}))
 	//nolint:gosec // Ignoring G114
 	if err := http.ListenAndServe(*metricFlag, nil); err != nil {

--- a/routes.go
+++ b/routes.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"log/slog"
 	"net/http"
 	"slices"
 	"strings"
@@ -56,7 +57,9 @@ func DisplayRoutes(w http.ResponseWriter, r *http.Request) {
 
 	// We still report it as a 404
 	w.WriteHeader(http.StatusNotFound)
-	w.Write([]byte(strings.Join(filteredRoutes, "\n")))
+	if _, err := w.Write([]byte(strings.Join(filteredRoutes, "\n"))); err != nil {
+		slog.Error("failed to write routes response", "error", err)
+	}
 }
 
 func SetupRoutes(r *chi.Mux, client *grpc.Client) {

--- a/routes_handler.go
+++ b/routes_handler.go
@@ -145,7 +145,9 @@ func writeBeacon(w http.ResponseWriter, beacon *grpc.HexBeacon, nextTime int64, 
 	}
 
 	w.WriteHeader(http.StatusOK)
-	w.Write(json)
+	if _, err := w.Write(json); err != nil {
+		slog.Error("failed to write beacon response", "error", err)
+	}
 }
 
 func GetLatest(c *grpc.Client, isV2 bool) func(http.ResponseWriter, *http.Request) {
@@ -202,7 +204,9 @@ func GetChains(c *grpc.Client) func(http.ResponseWriter, *http.Request) {
 			return
 		}
 
-		w.Write(json)
+		if _, err := w.Write(json); err != nil {
+			slog.Error("failed to write chains response", "error", err)
+		}
 	}
 }
 
@@ -263,7 +267,9 @@ func GetHealth(c *grpc.Client) func(http.ResponseWriter, *http.Request) {
 			return
 		}
 
-		w.Write(json)
+		if _, err := w.Write(json); err != nil {
+			slog.Error("[GetHealth] failed to write health response", "error", err)
+		}
 	}
 }
 
@@ -280,8 +286,11 @@ func GetBeaconIds(c *grpc.Client) func(http.ResponseWriter, *http.Request) {
 		if err != nil {
 			slog.Error("[GetBeaconIds] failed to encode beacon ids in json", "error", err)
 			http.Error(w, "Failed to produce beacon ids", http.StatusInternalServerError)
+			return
 		}
-		w.Write(json)
+		if _, err := w.Write(json); err != nil {
+			slog.Error("[GetBeaconIds] failed to write beacon ids response", "error", err)
+		}
 	}
 }
 
@@ -310,7 +319,9 @@ func GetInfoV1(c *grpc.Client) func(http.ResponseWriter, *http.Request) {
 			return
 		}
 
-		w.Write(json)
+		if _, err := w.Write(json); err != nil {
+			slog.Error("[GetInfoV1] failed to write chain info response", "error", err)
+		}
 	}
 }
 
@@ -339,7 +350,9 @@ func GetInfoV2(c *grpc.Client) func(http.ResponseWriter, *http.Request) {
 			return
 		}
 
-		w.Write(json)
+		if _, err := w.Write(json); err != nil {
+			slog.Error("[GetInfoV2] failed to write chain info response", "error", err)
+		}
 	}
 }
 


### PR DESCRIPTION


## Problem

Multiple HTTP handlers call `w.Write()` without checking the returned error. Write failures are silently ignored, making it difficult to debug network issues or client disconnections.

**Affected handlers:**
- `writeBeacon()`, `GetChains()`, `GetHealth()`, `GetBeaconIds()`, `GetInfoV1()`, `GetInfoV2()` in `routes_handler.go`
- `DisplayRoutes()` in `routes.go`
- `/chanz` handler in `metrics.go`

## Solution

Added error checking and logging for all `w.Write()` calls. Since HTTP headers may have already been sent when a write error occurs, we log the error but do not attempt to return an HTTP error status.

```go
if _, err := w.Write(json); err != nil {
    slog.Error("failed to write response", "error", err)
}
```

## Changes

- Added error handling for `w.Write()` in all HTTP handlers
- Error logs include context about which handler encountered the failure

## Testing

- All existing tests pass
- Code compiles successfully
