### PR TITLE
Use precise cache duration for "future beacon" error responses

### DIFF
--- a/grpc/grpc.go
+++ b/grpc/grpc.go
@@ -251,6 +251,21 @@ func (info *JsonInfoV2) ExpectedNext() (expectedTime int64, expectedRound uint64
 	return current*p + info.GenesisTime, uint64(current) + 1
 }
 
+// SecondsUntilRound returns the number of seconds from now until the given round becomes available.
+// Round N happens at GenesisTime + (N-1)*Period. Used for cache duration when returning "future beacon" errors.
+func (info *JsonInfoV2) SecondsUntilRound(round uint64) int64 {
+	if round == 0 {
+		return 0
+	}
+	p := int64(info.Period)
+	roundTime := info.GenesisTime + int64(round-1)*p
+	secs := roundTime - clock().Unix()
+	if secs < 0 {
+		return 0
+	}
+	return secs
+}
+
 func (j *JsonInfoV2) V1() *JsonInfoV1 {
 	return &JsonInfoV1{
 		PublicKey:   j.PublicKey,

--- a/grpc/grpc_test.go
+++ b/grpc/grpc_test.go
@@ -74,3 +74,62 @@ func TestNextBeaconTime(t *testing.T) {
 		})
 	}
 }
+
+func TestSecondsUntilRound(t *testing.T) {
+	now := int64(1718551765)
+	clock = func() time.Time {
+		return time.Unix(now, 0)
+	}
+
+	tests := []struct {
+		name     string
+		info     *JsonInfoV2
+		round    uint64
+		wantSecs int64
+	}{
+		{
+			name: "next round in 5 seconds",
+			info: &JsonInfoV2{
+				Period:      10,
+				GenesisTime: now - 25,
+			},
+			round:    4,
+			wantSecs: 5,
+		},
+		{
+			name: "round 0 returns 0",
+			info: &JsonInfoV2{
+				Period:      10,
+				GenesisTime: now - 25,
+			},
+			round:    0,
+			wantSecs: 0,
+		},
+		{
+			name: "round already passed returns 0",
+			info: &JsonInfoV2{
+				Period:      10,
+				GenesisTime: now - 100,
+			},
+			round:    5,
+			wantSecs: 0,
+		},
+		{
+			name: "round in 30 seconds",
+			info: &JsonInfoV2{
+				Period:      30,
+				GenesisTime: now,
+			},
+			round:    2,
+			wantSecs: 30,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.info.SecondsUntilRound(tt.round)
+			if got != tt.wantSecs {
+				t.Errorf("SecondsUntilRound() = %v, want %v", got, tt.wantSecs)
+			}
+		})
+	}
+}

--- a/routes_handler.go
+++ b/routes_handler.go
@@ -68,9 +68,9 @@ func getBeacon(c *grpc.Client, r *http.Request, round uint64) (*grpc.HexBeacon, 
 	// we refuse rounds too far in the future
 	if round >= nextRound+1 {
 		slog.Error("[GetBeacon] Future beacon was requested, unexpected", "requested", round, "expected", nextRound, "from", r.RemoteAddr)
-		// TODO: we could have a more precise nextTime value instead of just period
-		// we return the negative time to cache this response
-		return nil, -int64(info.Period), fmt.Errorf("future beacon was requested")
+		// Use precise time until next round for cache duration instead of full period
+		preciseCacheSeconds := info.SecondsUntilRound(nextRound)
+		return nil, -preciseCacheSeconds, fmt.Errorf("future beacon was requested")
 	}
 
 	var beacon *grpc.HexBeacon


### PR DESCRIPTION
## Problem

When a client requests a round that is too far in the future, the relay returns a "Requested future beacon" (425 Too Early) response. The response was cached for the **full chain period** (`info.Period`), even when the next valid round would become available sooner. That over-caches the error and can serve a stale "future beacon" response longer than necessary.

**Location:** `routes_handler.go` – `getBeacon()` when `round >= nextRound+1`

**Previous behavior:** Cache duration was always `-int64(info.Period)` (full period in seconds).

**Impact:**
- Suboptimal caching: error responses cached for the whole period instead of until the next round
- Clients may see the "future beacon" error longer than needed
- A TODO in code noted this improvement

## Solution

Compute the **exact time until the next round** and use that as the cache duration. Round N is at `GenesisTime + (N-1)*Period`; seconds from now until that time is used for the negative `nextTime` (cache duration) when returning the future-beacon error.

- Added **`SecondsUntilRound(round uint64) int64`** on `JsonInfoV2` in `grpc/grpc.go`: returns seconds from now until the given round, or 0 if the round is in the past or round is 0.
- In `getBeacon()`, when `round >= nextRound+1`, use `info.SecondsUntilRound(nextRound)` instead of `info.Period` for the cache duration.
- Removed the TODO about using a more precise nextTime.

## Changes

**`grpc/grpc.go`**
- New method `SecondsUntilRound(round uint64) int64` on `JsonInfoV2`: computes round time as `GenesisTime + (round-1)*Period`, returns `max(0, roundTime - now)`.

**`routes_handler.go`**
- In the future-beacon branch: set `preciseCacheSeconds := info.SecondsUntilRound(nextRound)` and return `-preciseCacheSeconds` instead of `-int64(info.Period)`.
- Removed the TODO comment.

**`grpc/grpc_test.go`**
- New test **`TestSecondsUntilRound`**: next round in 5s, round 0 returns 0, round already passed returns 0, round in 30s.

## Testing

- `go test ./grpc/... -v -run TestSecondsUntilRound`
- `go test ./grpc/... -v -run TestNextBeaconTime` (unchanged)
- `go build ./...`

## Notes

- Cache duration is now at most the time until the next round; it can be less than the full period when the next round is soon.
- No change to success paths or to when the "future beacon" error is returned; only the cache duration for that error is improved.
